### PR TITLE
Fix Django 1.11 bug

### DIFF
--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.10'
+VERSION = '0.3.11'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_url_names': [],

--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.11'
+VERSION = '0.3.10-django-11.1-hotfix'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_url_names': [],

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -81,7 +81,7 @@ class SwaggerUIView(View):
             }
         }
         response = render_to_response(
-            template_name, RequestContext(request, data))
+            template_name, {'request': request, **data})
 
         return response
 


### PR DESCRIPTION
* render() must receive a dictionary of context rather than
  RequestContext.
* Bump version to 0.3.11